### PR TITLE
After Midnight 2024

### DIFF
--- a/SceneDateExceptions.json
+++ b/SceneDateExceptions.json
@@ -38,5 +38,6 @@
     "369003": "YYYY MM DD",
     "375658": "YYYY MM DD",
     "403243": "YYYY MM DD",
-    "435034": "YYYY MM DD"
+    "435034": "YYYY MM DD",
+    "441733": "YYYY MM DD"
 }

--- a/SceneNameExceptions.json
+++ b/SceneNameExceptions.json
@@ -524,5 +524,6 @@
     "413074": "Mayfair Witches",
     "414734": "The Continental",
     "415239": "The Diplomat US",
-    "435034": "AEW Collision"
+    "435034": "AEW Collision",
+    "441733": "After Midnight 2024"
 }

--- a/TraktSceneDateExceptions.json
+++ b/TraktSceneDateExceptions.json
@@ -37,5 +37,6 @@
     "152183": "YYYY MM DD",
     "157355": "YYYY MM DD",
     "181207": "YYYY MM DD",
-    "205472": "YYYY MM DD"
+    "205472": "YYYY MM DD",
+    "219964": "YYYY MM DD"
 }

--- a/TraktSceneNameExceptions.json
+++ b/TraktSceneNameExceptions.json
@@ -524,5 +524,6 @@
     "187928": "Cowboy Bebop 2021",
     "196192": "The Diplomat US",
     "197457": "Mayfair Witches",
-    "205472": "AEW Collision"
+    "205472": "AEW Collision",
+    "219964": "After Midnight 2024"
 }


### PR DESCRIPTION
Current name format: `After.Midnight.2024.2024.01.16.blahhhh`

Only one episode out so far, don't know if you want to hold out for a couple more, see if they drop the '2024'.